### PR TITLE
Update content and structure in Mobilise, Recover, and Strengthen pages

### DIFF
--- a/app/mobilise/page.tsx
+++ b/app/mobilise/page.tsx
@@ -96,7 +96,7 @@ export default function MobilisePage() {
           </p>
         </div>
       </CollapsibleBox>
-      <CollapsibleBox title="Recent tight" defaultOpen={false}>
+      <CollapsibleBox title="Recently tight" defaultOpen={false}>
         <div className="space-y-2">
           <p className="text-muted-foreground">
             This is a list of muscles recently found to be tight in your body during training.

--- a/app/recover/page.tsx
+++ b/app/recover/page.tsx
@@ -1,18 +1,60 @@
+'use client'
+
 import { Button } from '@/components/ui/button'
 import { CollapsibleBox } from '@/components/common/collapsible-box'
+import { useImbalanceImage } from '@/hooks/use-imbalance-image'
+import { ImageError, ImageLoading, ImagePlaceholder } from '@/components/common/image-states'
+import Image from 'next/image'
 import Link from 'next/link'
 
 export default function RecoverPage() {
+  const { imageUrl, loading: imageLoading, error: imageError } = useImbalanceImage()
+
   return (
     <div className="container mx-auto px-4 py-6">
       <h1>Recover</h1>
 
-      <CollapsibleBox title="Recovery Guide" defaultOpen={false}>
+      <CollapsibleBox title="Objective: Stretch Functional Imbalances Most" defaultOpen={false}>
         <div className="space-y-2">
           <p className="text-muted-foreground">
-            Recovery is just as important as the workout itself. Focus on gentle movements that
-            promote blood flow and help your muscles recover. This will help reduce soreness and
-            prepare your body for your next workout session.
+            Only stretch the muscles that you have just worked in &ldquo;Strengthen&rdquo;, focusing
+            most on your muscles with a higher Functional Imbalances Risk (FIR). Stretching will
+            help these muscles to recover quicker, which will help you feel fresher and move better,
+            leading to better results in your next training session. Hold each stretch for 20sec+.
+            Breathe deeply and push further into each stretch every time you breathe out.
+          </p>
+        </div>
+      </CollapsibleBox>
+
+      <div className="mb-8 aspect-[4/3] grid place-items-center bg-muted/30 rounded-lg overflow-hidden">
+        {imageLoading ? (
+          <ImageLoading />
+        ) : imageError ? (
+          <ImageError message={imageError} />
+        ) : !imageUrl ? (
+          <ImagePlaceholder />
+        ) : (
+          <Image
+            src={imageUrl}
+            alt="Personal imbalance image"
+            width={600}
+            height={450}
+            className="w-full h-full object-cover"
+            priority
+          />
+        )}
+      </div>
+
+      <CollapsibleBox title="Training days" defaultOpen={false}>
+        <div className="space-y-2">
+          <p className="text-muted-foreground">
+            Your Recovery Training Program has been split into Day 1 and Day 2. Each Day will focus
+            on stretching a different combination of muscles groups that matches the muscles you
+            have just worked in &ldquo;Strengthen&rdquo;. Therefore please follow the same Training
+            Day that you did in &ldquo;Strengthen&rdquo; (i.e. follow Day 1 Strength Training with
+            Day 1 Recovery Training). If you did &ldquo;Create your own workout&rdquo; in
+            &ldquo;Strengthen&rdquo; then please stretch the muscles that you have just worked,
+            focusing most on stretching your muscles with a higher FIR.
           </p>
         </div>
       </CollapsibleBox>

--- a/app/strengthen/page.tsx
+++ b/app/strengthen/page.tsx
@@ -21,11 +21,9 @@ export default function StrengthenPage() {
       <CollapsibleBox title="Objective: Strengthen functional imbalances most" defaultOpen={false}>
         <div className="space-y-2">
           <p className="text-muted-foreground">
-            Only stretch the muscles that you have just worked in "Strengthen", focusing most on
-            your muscles with a higher Functional Imbalances Risk (FIR). Stretching will help these
-            muscles to recover quicker, which will help you feel fresher and move better, leading to
-            better results in your next training session. Hold each stretch for 20sec+. Breathe
-            deeply and push further into each stretch every time you breathe out.
+            Your goal is to work all the muscles in your body, focusing most on strengthening your
+            muscles with a higher Functional Imbalances Risk (FIR). This will help you to get better
+            results from your training.
           </p>
         </div>
       </CollapsibleBox>
@@ -52,12 +50,12 @@ export default function StrengthenPage() {
       <CollapsibleBox title="Training days" defaultOpen={false}>
         <div className="space-y-2">
           <p className="text-muted-foreground">
-            Your Recovery Training Program has been split into Day 1 and Day 2. Each Day will focus
-            on stretching a different combination of muscles groups that matches the muscles you
-            have just worked in "Strengthen". Therefore please follow the same Training Day that you
-            did in "Strengthen" (i.e. follow Day 1 Strength Training with Day 1 Recovery Training).
-            If you did "Create your own workout" in "Strengthen" then please stretch the muscles
-            that you have just worked, focusing most on stretching your muscles with a higher FIR.
+            Your Strength training program has been split into Day 1 and Day 2. Each Day will focus
+            on working a different combination of muscles groups. Please follow the training Days in
+            order(i.e. follow Day 1 training with Day 2 training, then go back to Day 1) to ensure
+            that you keep to the ideal FIR training ratios calculated for your body. If for any
+            reason you are unable to do Day 1 or 2 training, you can &ldquo;Create your own
+            workout&rdquo;.
           </p>
         </div>
       </CollapsibleBox>


### PR DESCRIPTION
- Corrected the title in MobilisePage from "Recent tight" to "Recently tight".
- Enhanced RecoverPage by adding an image display feature with loading and error states, and updated the title to "Objective: Stretch Functional Imbalances Most".
- Revised text in StrengthenPage to clarify the focus on strengthening muscles with a higher Functional Imbalances Risk (FIR) and updated the "Training days" section for better clarity on training progression.